### PR TITLE
Potential fix for code scanning alert no. 22: Unsigned difference expression compared to zero

### DIFF
--- a/fdbserver/workloads/RawTenantAccessWorkload.actor.cpp
+++ b/fdbserver/workloads/RawTenantAccessWorkload.actor.cpp
@@ -87,7 +87,7 @@ struct RawTenantAccessWorkload : TestWorkload {
 
 	bool hasNonexistentTenant() const { return lastCreatedTenants.size() + idx2Tid.size() < tenantCount; }
 
-	bool hasExistingTenant() const { return idx2Tid.size() - lastDeletedTenants.size() > 0; }
+	bool hasExistingTenant() const { return (int64_t)idx2Tid.size() - (int64_t)lastDeletedTenants.size() > 0; }
 
 	int64_t extractTenantId(ValueRef value) const {
 		int64_t id;


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/foundationdb/security/code-scanning/22](https://github.com/codeallthethingsbreak/foundationdb/security/code-scanning/22)

To fix the issue, we need to ensure that the subtraction operation does not underflow. The best approach is to cast the unsigned values to a signed type (e.g., `int64_t`) before performing the subtraction. This ensures that the result of the subtraction can represent negative values if `lastDeletedTenants.size()` is greater than `idx2Tid.size()`. The comparison will then behave as intended.

The specific change involves modifying the expression `idx2Tid.size() - lastDeletedTenants.size() > 0` to `(int64_t)idx2Tid.size() - (int64_t)lastDeletedTenants.size() > 0`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
