### PR TITLE
Potential fix for code scanning alert no. 14: Likely overrunning write

### DIFF
--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -46,7 +46,7 @@ std::string awsV4URIEncode(const std::string& s, bool encodeSlash) {
 		else if (c == '/')
 			o.append(encodeSlash ? "%2F" : "/");
 		else {
-			sprintf(buf, "%%%.02X", c);
+			snprintf(buf, sizeof(buf), "%%%.02X", c);
 			o.append(buf);
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/foundationdb/security/code-scanning/14](https://github.com/codeallthethingsbreak/foundationdb/security/code-scanning/14)

To fix the issue, we should replace the unsafe `sprintf` call with `snprintf`, which allows us to specify the maximum number of characters to write to the buffer, including the null terminator. This ensures that the buffer is not overrun. Specifically:
1. Replace `sprintf(buf, "%%%.02X", c);` with `snprintf(buf, sizeof(buf), "%%%.02X", c);` to limit the write operation to the size of the `buf` array.
2. Ensure that the buffer size is sufficient for the format string and the null terminator. The current size of 4 bytes is adequate for the format `"%%%.02X"`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
